### PR TITLE
Call addIsConnected when building NTMultiChannel

### DIFF
--- a/src/org/epics/pvaClient/PvaClientNTMultiData.java
+++ b/src/org/epics/pvaClient/PvaClientNTMultiData.java
@@ -89,7 +89,7 @@ public class PvaClientNTMultiData
             unionValue[i] = pvDataCreate.createPVUnion(u);
         }
         NTMultiChannelBuilder builder = NTMultiChannel.createBuilder();
-        builder.value(u);
+        builder.value(u).addIsConnected();
         if(pvRequest.getSubField("field.alarm")!=null)
         {
             gotAlarm = true;


### PR DESCRIPTION
isConnected is not a required field of NTMultiChannel, so an instance of NTMultiChannel wrapper class in normativeTypesJava built by the builder does not have this by default and addIsConnected must be called to provide this field.
