### PR TITLE
PvaClient.get(prividerNames) bug was comma separated instead of space

### DIFF
--- a/src/org/epics/pvaClient/PvaClient.java
+++ b/src/org/epics/pvaClient/PvaClient.java
@@ -34,7 +34,7 @@ public class PvaClient implements Requester {
     static public synchronized PvaClient get(String providerNames) {
         if(pvaClient==null) {
             pvaClient = new PvaClient();
-            String[] names = providerNames.split("[,\\s]+");
+            String[] names = providerNames.split("\\s+");
             for (String name : names)
             {
                 if(name.equals("pva")) {


### PR DESCRIPTION
Fix bug described by title
