### PR TITLE
Fix bugs for stateChangeRequester and  channelGet

### DIFF
--- a/src/org/epics/pvaClient/PvaClientChannel.java
+++ b/src/org/epics/pvaClient/PvaClientChannel.java
@@ -290,6 +290,7 @@ public class PvaClientChannel implements ChannelRequester,Requester{
             PvaClientChannelStateChangeRequester stateChangeRequester)
     {
         this.stateChangeRequester = stateChangeRequester;
+        stateChangeRequester.channelStateChange(this,channel.isConnected());
     }
     /**
      * Clear user callback for change of state.

--- a/src/org/epics/pvaClient/PvaClientGet.java
+++ b/src/org/epics/pvaClient/PvaClientGet.java
@@ -258,7 +258,7 @@ public class PvaClientGet implements ChannelGetRequester
     {
         if(isDestroyed) throw new RuntimeException("pvaClientGet was destroyed");
         if(connectState==GetConnectState.connectIdle) connect();
-        if(getState!=GetState.getIdle) {
+        if(getState==GetState.getActive) {
             String message = "channel "
                     + channel.getChannelName() 
                     +  " PvaClientGet::issueGet get aleady active ";
@@ -278,7 +278,6 @@ public class PvaClientGet implements ChannelGetRequester
         lock.lock();
         try {
             if(getState==GetState.getComplete) {
-                getState = GetState.getIdle;
                 return channelGetStatus;
             }
             if(getState!=GetState.getActive){
@@ -295,7 +294,7 @@ public class PvaClientGet implements ChannelGetRequester
                         + " InterruptedException " + e.getMessage();
                 throw new RuntimeException(message);
             }
-            getState = GetState.getIdle;
+            getState = GetState.getComplete;
             return channelGetStatus;
         } finally {
             lock.unlock();


### PR DESCRIPTION
1) Call stateChangeRequester when connecting.
2) channelGet:: get now only does one get instead of two.